### PR TITLE
51 fix création de personne suite du user story

### DIFF
--- a/src/main/java/com/easygroup/controller/AuthController.java
+++ b/src/main/java/com/easygroup/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.easygroup.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
@@ -24,7 +23,6 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Autowired
     public AuthController(AuthService authService) {
         this.authService = authService;
     }

--- a/src/main/java/com/easygroup/controller/AuthController.java
+++ b/src/main/java/com/easygroup/controller/AuthController.java
@@ -3,7 +3,6 @@ package com.easygroup.controller;
 import com.easygroup.dto.AuthResponse;
 import com.easygroup.dto.LoginRequest;
 import com.easygroup.dto.RegisterRequest;
-import com.easygroup.entity.User;
 import com.easygroup.service.AuthService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,8 +39,6 @@ public class AuthController {
             @RequestBody @Valid RegisterRequest request,
             HttpServletResponse response) {
         try {
-            User user = authService.register(request.getEmail(), request.getPassword(), request.getFirstName(), request.getLastName());
-
             // Authenticate the user after registration to generate a token and set it as a cookie
             AuthResponse authResponse = authService.authenticate(request.getEmail(), request.getPassword(), response);
 

--- a/src/main/java/com/easygroup/controller/GroupController.java
+++ b/src/main/java/com/easygroup/controller/GroupController.java
@@ -3,7 +3,6 @@ package com.easygroup.controller;
 import com.easygroup.dto.GroupResponse;
 import com.easygroup.service.GroupService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/easygroup/controller/ListController.java
+++ b/src/main/java/com/easygroup/controller/ListController.java
@@ -5,7 +5,6 @@ import com.easygroup.dto.ListResponse;
 import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.User;
 import com.easygroup.service.ListService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/easygroup/controller/ListController.java
+++ b/src/main/java/com/easygroup/controller/ListController.java
@@ -2,7 +2,7 @@ package com.easygroup.controller;
 
 import com.easygroup.dto.ListRequest;
 import com.easygroup.dto.ListResponse;
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.User;
 import com.easygroup.service.ListService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +27,7 @@ public class ListController {
         System.out.println("USER = " + user);
 
         try{
-            List list = listService.save(request.getName(), user);
+            ListEntity list = listService.save(request.getName(), user);
 
             ListResponse response = new ListResponse(
                     list.getId(),

--- a/src/main/java/com/easygroup/controller/ListController.java
+++ b/src/main/java/com/easygroup/controller/ListController.java
@@ -16,7 +16,6 @@ public class ListController {
 
     private final ListService listService;
 
-    @Autowired
     public ListController(ListService listService){
         this.listService = listService;
     }

--- a/src/main/java/com/easygroup/controller/ListShareController.java
+++ b/src/main/java/com/easygroup/controller/ListShareController.java
@@ -1,12 +1,10 @@
 package com.easygroup.controller;
 
-import com.easygroup.dto.ListResponse;
 import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.ListShare;
 import com.easygroup.entity.User;
 import com.easygroup.service.ListService;
 import com.easygroup.service.ListShareService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +18,6 @@ public class ListShareController {
     private final ListShareService listShareService;
     private final ListService listService;
 
-    @Autowired
     public ListShareController(ListShareService listShareService, ListService listService){
         this.listShareService = listShareService;
         this.listService = listService;

--- a/src/main/java/com/easygroup/controller/ListShareController.java
+++ b/src/main/java/com/easygroup/controller/ListShareController.java
@@ -1,7 +1,7 @@
 package com.easygroup.controller;
 
 import com.easygroup.dto.ListResponse;
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.ListShare;
 import com.easygroup.entity.User;
 import com.easygroup.service.ListService;
@@ -29,7 +29,7 @@ public class ListShareController {
     //share a list to a user
     @PostMapping
     public ResponseEntity<ListShare> shareList(@AuthenticationPrincipal User owner, @RequestBody User userSharedTo, @PathVariable UUID listId){
-        List list = this.listService.findById(listId).orElseThrow();
+        ListEntity list = this.listService.findById(listId).orElseThrow();
 
         if (owner.getLists().stream().anyMatch(l -> l.equals(list))){
             ListShare listShared = this.listShareService.shareList(list, userSharedTo);
@@ -41,11 +41,11 @@ public class ListShareController {
 
     //Unshare a list to a user
     @DeleteMapping("/{sharedUserId}")
-    public ResponseEntity<List> deleteListShare(@AuthenticationPrincipal User owner, @RequestBody User userUnshareTo, @PathVariable UUID listId){
-        List list = this.listService.findById(listId).orElseThrow();
+    public ResponseEntity<ListEntity> deleteListShare(@AuthenticationPrincipal User owner, @RequestBody User userUnshareTo, @PathVariable UUID listId){
+        ListEntity list = this.listService.findById(listId).orElseThrow();
 
         if (owner.getLists().stream().anyMatch(l -> l.equals(list))){
-            List listUnshared = this.listShareService.unshareList(list, userUnshareTo);
+            ListEntity listUnshared = this.listShareService.unshareList(list, userUnshareTo);
 
             return ResponseEntity.ok(listUnshared);
         }

--- a/src/main/java/com/easygroup/controller/PersonController.java
+++ b/src/main/java/com/easygroup/controller/PersonController.java
@@ -1,18 +1,23 @@
 package com.easygroup.controller;
 
+import com.easygroup.dto.PersonRequest;
+import com.easygroup.dto.PersonResponse;
 import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.Person;
 import com.easygroup.entity.User;
+import com.easygroup.mapper.PersonMapper;
 import com.easygroup.service.ListService;
 import com.easygroup.service.PersonService;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+
 
 /**
  * REST controller for managing persons associated with a list.
@@ -24,7 +29,6 @@ public class PersonController {
     private final PersonService personService;
     private final ListService listService;
 
-    @Autowired
     public PersonController(PersonService personService, ListService listService) {
         this.personService = personService;
         this.listService = listService;
@@ -34,7 +38,7 @@ public class PersonController {
      * Get all persons belonging to a specific list.
      *
      * @param listId the ID of the list
-     * @param user the authenticated user
+     * @param user   the authenticated user
      * @return the list of persons if the list is owned by the user, 403 otherwise
      */
     @GetMapping
@@ -56,13 +60,14 @@ public class PersonController {
      *
      * @param listId the ID of the list
      * @param person the person object to create
-     * @param user the authenticated user
+     * @param user   the authenticated user
      * @return the created person, or 403 if the list is not owned by the user
      */
+
     @PostMapping
-    public ResponseEntity<Person> createPerson(
+    public ResponseEntity<PersonResponse> createPerson(
             @PathVariable UUID listId,
-            @RequestBody Person person,
+            @RequestBody @Valid PersonRequest personRequest,
             @AuthenticationPrincipal User user) {
 
         ListEntity list = listService.findByIdAndUserId(listId, user.getId());
@@ -70,17 +75,26 @@ public class PersonController {
             return ResponseEntity.status(403).build();
         }
 
+        Person person = new Person();
+        person.setName(personRequest.getName());
+        person.setGender(personRequest.getGender());
+        person.setAge(personRequest.getAge());
+        person.setFrenchLevel(personRequest.getFrenchLevel());
+        person.setOldDwwm(personRequest.getOldDwwm());
+        person.setTechLevel(personRequest.getTechLevel());
+        person.setProfile(personRequest.getProfile());
         person.setList(list);
+
         Person created = personService.save(person);
-        return ResponseEntity.ok(created);
+        return ResponseEntity.ok(PersonMapper.toDto(created));
     }
 
     /**
      * Delete a person by ID from a specific list.
      *
-     * @param listId the ID of the list
+     * @param listId   the ID of the list
      * @param personId the ID of the person to delete
-     * @param user the authenticated user
+     * @param user     the authenticated user
      * @return 204 No Content on success, 403 if not authorized
      */
     @DeleteMapping("/{personId}")

--- a/src/main/java/com/easygroup/controller/UserController.java
+++ b/src/main/java/com/easygroup/controller/UserController.java
@@ -4,7 +4,6 @@ import com.easygroup.entity.User;
 import com.easygroup.security.IsAdmin;
 import com.easygroup.security.IsAuthenticated;
 import com.easygroup.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,7 +23,6 @@ public class UserController {
 
     private final UserService userService;
 
-    @Autowired
     public UserController(UserService userService) {
         this.userService = userService;
     }

--- a/src/main/java/com/easygroup/entity/Draw.java
+++ b/src/main/java/com/easygroup/entity/Draw.java
@@ -28,7 +28,7 @@ public class Draw {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "list_id", nullable = false)
-    private List list;
+    private ListEntity list;
 
     @Column
     private String title;

--- a/src/main/java/com/easygroup/entity/ListEntity.java
+++ b/src/main/java/com/easygroup/entity/ListEntity.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class List {
+public class ListEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/easygroup/entity/ListShare.java
+++ b/src/main/java/com/easygroup/entity/ListShare.java
@@ -27,7 +27,7 @@ public class ListShare {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "list_id", nullable = false)
-    private List list;
+    private ListEntity list;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shared_with_user_id", nullable = false)

--- a/src/main/java/com/easygroup/entity/Person.java
+++ b/src/main/java/com/easygroup/entity/Person.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Entity representing a person in a list.
  * Each person has various attributes used for group creation.
@@ -46,9 +48,11 @@ public class Person {
     @Column(nullable = false)
     private Profile profile;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "list_id", nullable = false)
-    private ListEntity list;
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "list_id", nullable = false)
+@JsonIgnoreProperties({"user", "persons", "listShares","shares"})  // 👈 évite cascade
+private ListEntity list;
+
 
     @OneToMany(mappedBy = "person")
     private java.util.List<GroupPerson> groupPersons = new ArrayList<>();

--- a/src/main/java/com/easygroup/entity/Person.java
+++ b/src/main/java/com/easygroup/entity/Person.java
@@ -48,7 +48,7 @@ public class Person {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "list_id", nullable = false)
-    private List list;
+    private ListEntity list;
 
     @OneToMany(mappedBy = "person")
     private java.util.List<GroupPerson> groupPersons = new ArrayList<>();

--- a/src/main/java/com/easygroup/entity/User.java
+++ b/src/main/java/com/easygroup/entity/User.java
@@ -59,7 +59,7 @@ public class User {
     private Role role = Role.USER;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private java.util.List<List> lists = new ArrayList<>();
+    private java.util.List<ListEntity> lists = new ArrayList<>();
 
     @OneToMany(mappedBy = "sharedWithUser", cascade = CascadeType.ALL, orphanRemoval = true)
     private java.util.List<ListShare> sharedLists = new ArrayList<>();

--- a/src/main/java/com/easygroup/mapper/PersonMapper.java
+++ b/src/main/java/com/easygroup/mapper/PersonMapper.java
@@ -1,0 +1,20 @@
+package com.easygroup.mapper;
+
+import com.easygroup.dto.PersonResponse;
+import com.easygroup.entity.Person;
+
+public class PersonMapper {
+
+    public static PersonResponse toDto(Person person) {
+        return new PersonResponse(
+                person.getId(),
+                person.getName(),
+                person.getGender().name(),
+                person.getAge(),
+                person.getFrenchLevel(),
+                person.getOldDwwm(),
+                person.getTechLevel(),
+                person.getProfile().name()
+        );
+    }
+}

--- a/src/main/java/com/easygroup/repository/DrawRepository.java
+++ b/src/main/java/com/easygroup/repository/DrawRepository.java
@@ -1,7 +1,7 @@
 package com.easygroup.repository;
 
 import com.easygroup.entity.Draw;
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -19,7 +19,7 @@ public interface DrawRepository extends JpaRepository<Draw, UUID> {
      * @param list the list for which draws were created
      * @return a list of Draw objects
      */
-    java.util.List<Draw> findByList(List list);
+    java.util.List<Draw> findByList(ListEntity list);
 
     /**
      * Find all draws for a specific list ordered by creation date (newest first).
@@ -27,7 +27,7 @@ public interface DrawRepository extends JpaRepository<Draw, UUID> {
      * @param list the list for which draws were created
      * @return a list of Draw objects ordered by creation date
      */
-    java.util.List<Draw> findByListOrderByCreatedAtDesc(List list);
+    java.util.List<Draw> findByListOrderByCreatedAtDesc(ListEntity list);
 
     /**
      * Count the number of draws for a specific list.
@@ -35,5 +35,5 @@ public interface DrawRepository extends JpaRepository<Draw, UUID> {
      * @param list the list for which draws were created
      * @return the number of draws for the list
      */
-    long countByList(List list);
+    long countByList(ListEntity list);
 }

--- a/src/main/java/com/easygroup/repository/ListRepository.java
+++ b/src/main/java/com/easygroup/repository/ListRepository.java
@@ -1,6 +1,7 @@
 package com.easygroup.repository;
 
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
+import com.easygroup.entity.Person;
 import com.easygroup.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,7 @@ import java.util.UUID;
  * Repository for ListEntity.
  */
 @Repository
-public interface ListRepository extends JpaRepository<List, UUID> {
+public interface ListRepository extends JpaRepository<ListEntity, UUID> {
 
     /**
      * Find all lists owned by a user.
@@ -20,7 +21,7 @@ public interface ListRepository extends JpaRepository<List, UUID> {
      * @param user the user who owns the lists
      * @return a list of ListEntity objects
      */
-    java.util.List<List> findByUser(User user);
+    java.util.List<ListEntity> findByUser(User user);
 
     /**
      * Find a list by its name and owner.
@@ -29,7 +30,7 @@ public interface ListRepository extends JpaRepository<List, UUID> {
      * @param user the owner of the list
      * @return an Optional containing the list if found
      */
-    Optional<List> findByNameAndUser(String name, User user);
+    Optional<ListEntity> findByNameAndUser(String name, User user);
 
     /**
      * Check if a list exists with the given name and owner.
@@ -39,4 +40,6 @@ public interface ListRepository extends JpaRepository<List, UUID> {
      * @return true if a list exists with the name and owner
      */
     boolean existsByNameAndUser(String name, User user);
+
+Optional<ListEntity> findByIdAndUser_Id(UUID listId, UUID userId);
 }

--- a/src/main/java/com/easygroup/repository/ListRepository.java
+++ b/src/main/java/com/easygroup/repository/ListRepository.java
@@ -1,7 +1,6 @@
 package com.easygroup.repository;
 
 import com.easygroup.entity.ListEntity;
-import com.easygroup.entity.Person;
 import com.easygroup.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/easygroup/repository/ListShareRepository.java
+++ b/src/main/java/com/easygroup/repository/ListShareRepository.java
@@ -1,6 +1,6 @@
 package com.easygroup.repository;
 
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.ListShare;
 import com.easygroup.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,7 +29,7 @@ public interface ListShareRepository extends JpaRepository<ListShare, UUID> {
      * @param list the list that is shared
      * @return a list of ListShare objects
      */
-    java.util.List<ListShare> findByList(List list);
+    java.util.List<ListShare> findByList(ListEntity list);
 
     /**
      * Find a list share by list and user.
@@ -38,7 +38,7 @@ public interface ListShareRepository extends JpaRepository<ListShare, UUID> {
      * @param sharedWithUser the user who has access to the shared list
      * @return an Optional containing the ListShare if found
      */
-    Optional<ListShare> findByListAndSharedWithUser(List list, User sharedWithUser);
+    Optional<ListShare> findByListAndSharedWithUser(ListEntity list, User sharedWithUser);
 
     /**
      * Check if a list is shared with a specific user.
@@ -47,5 +47,5 @@ public interface ListShareRepository extends JpaRepository<ListShare, UUID> {
      * @param sharedWithUser the user to check
      * @return true if the list is shared with the user
      */
-    boolean existsByListAndSharedWithUser(List list, User sharedWithUser);
+    boolean existsByListAndSharedWithUser(ListEntity list, User sharedWithUser);
 }

--- a/src/main/java/com/easygroup/repository/PersonRepository.java
+++ b/src/main/java/com/easygroup/repository/PersonRepository.java
@@ -5,7 +5,6 @@ import com.easygroup.entity.Person;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 /**

--- a/src/main/java/com/easygroup/repository/PersonRepository.java
+++ b/src/main/java/com/easygroup/repository/PersonRepository.java
@@ -1,10 +1,11 @@
 package com.easygroup.repository;
 
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.Person;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -19,7 +20,7 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
      * @param list the list containing the persons
      * @return a list of Person objects
      */
-    java.util.List<Person> findByList(List list);
+    java.util.List<Person> findByList(ListEntity list);
 
     /**
      * Find all persons in a specific list ordered by name.
@@ -27,7 +28,7 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
      * @param list the list containing the persons
      * @return a list of Person objects ordered by name
      */
-    java.util.List<Person> findByListOrderByNameAsc(List list);
+    java.util.List<Person> findByListOrderByNameAsc(ListEntity list);
 
     /**
      * Count the number of persons in a specific list.
@@ -35,12 +36,14 @@ public interface PersonRepository extends JpaRepository<Person, UUID> {
      * @param list the list containing the persons
      * @return the number of persons in the list
      */
-    long countByList(List list);
+    long countByList(ListEntity list);
 
     /**
      * Delete all persons in a specific list.
      * 
      * @param list the list containing the persons to delete
      */
-    void deleteByList(List list);
+    void deleteByList(ListEntity list);
+
+
 }

--- a/src/main/java/com/easygroup/service/AuthService.java
+++ b/src/main/java/com/easygroup/service/AuthService.java
@@ -4,11 +4,8 @@ import com.easygroup.dto.AuthResponse;
 import com.easygroup.entity.User;
 import com.easygroup.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,11 +20,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
-    private final AuthenticationManager authenticationManager;
     private final UserService userService;
     private final CookieService cookieService;
 
-    @Autowired
     public AuthService(
             UserRepository userRepository,
             PasswordEncoder passwordEncoder,
@@ -38,7 +33,7 @@ public class AuthService {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
-        this.authenticationManager = authenticationConfiguration.getAuthenticationManager(); // 👈 Appel direct
+        authenticationConfiguration.getAuthenticationManager();
         this.userService = userService;
         this.cookieService = cookieService;
     }
@@ -67,9 +62,6 @@ public class AuthService {
     }
 
     public AuthResponse authenticate(String email, String password, HttpServletResponse response) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(email, password));
-
         User user = userService.getActivatedUserByEmail(email);
         String token = jwtService.generateToken(user);
 

--- a/src/main/java/com/easygroup/service/DrawService.java
+++ b/src/main/java/com/easygroup/service/DrawService.java
@@ -35,9 +35,6 @@ public class DrawService {
     @Autowired
     private GroupGenerationService groupGenerationService;
     public DrawResponse generateGroups(GenerateGroupsRequest request, UUID userId, UUID listId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found with id: " + userId));
-
         ListEntity list = validateUserListAccess(userId, listId);
 
         Draw draw = convertDtoToEntity(request, list);

--- a/src/main/java/com/easygroup/service/DrawService.java
+++ b/src/main/java/com/easygroup/service/DrawService.java
@@ -3,7 +3,7 @@ package com.easygroup.service;
 import com.easygroup.dto.DrawResponse;
 import com.easygroup.dto.GenerateGroupsRequest;
 import com.easygroup.entity.Draw;
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.User;
 import com.easygroup.repository.DrawRepository;
 import com.easygroup.repository.ListRepository;
@@ -38,7 +38,7 @@ public class DrawService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found with id: " + userId));
 
-        List list = validateUserListAccess(userId, listId);
+        ListEntity list = validateUserListAccess(userId, listId);
 
         Draw draw = convertDtoToEntity(request, list);
         Draw savedDraw = drawRepository.save(draw);
@@ -47,15 +47,15 @@ public class DrawService {
     }
 
     public java.util.List<DrawResponse> getDrawsForList(UUID userId, UUID listId) {
-        List list = validateUserListAccess(userId, listId);
+        ListEntity list = validateUserListAccess(userId, listId);
         java.util.List<Draw> draws = drawRepository.findByListOrderByCreatedAtDesc(list);
         return draws.stream()
                 .map(this::convertEntityToDto)
                 .collect(Collectors.toList());
     }
 
-    private List validateUserListAccess(UUID userId, UUID listId) {
-        List list = listRepository.findById(listId)
+    private ListEntity validateUserListAccess(UUID userId, UUID listId) {
+        ListEntity list = listRepository.findById(listId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "List not found with id: " + listId));
 
         //to be added && !hasSharedAccess(userId, listId)
@@ -74,7 +74,7 @@ public class DrawService {
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
         return "Groups for " + listName + " - " + timestamp;
     }
-    private Draw convertDtoToEntity(GenerateGroupsRequest request, List list) {
+    private Draw convertDtoToEntity(GenerateGroupsRequest request, ListEntity list) {
         Draw draw = new Draw();
         draw.setTitle(generateTitle(request.getTitle(), list.getName()));
         draw.setList(list);

--- a/src/main/java/com/easygroup/service/ListService.java
+++ b/src/main/java/com/easygroup/service/ListService.java
@@ -5,7 +5,6 @@ import com.easygroup.entity.ListShare;
 import com.easygroup.entity.User;
 import com.easygroup.repository.ListRepository;
 import com.easygroup.repository.ListShareRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +22,6 @@ public class ListService {
     private final ListRepository listRepository;
     private final ListShareRepository listShareRepository;
 
-    @Autowired
     public ListService(ListRepository listRepository, ListShareRepository listShareRepository) {
         this.listRepository = listRepository;
         this.listShareRepository = listShareRepository;

--- a/src/main/java/com/easygroup/service/ListService.java
+++ b/src/main/java/com/easygroup/service/ListService.java
@@ -1,6 +1,6 @@
 package com.easygroup.service;
 
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.ListShare;
 import com.easygroup.entity.User;
 import com.easygroup.repository.ListRepository;
@@ -34,7 +34,7 @@ public class ListService {
      *
      * @return a list of all lists
      */
-    public java.util.List<List> findAll() {
+    public java.util.List<ListEntity> findAll() {
         return listRepository.findAll();
     }
 
@@ -44,7 +44,7 @@ public class ListService {
      * @param id the list ID
      * @return an Optional containing the list if found
      */
-    public Optional<List> findById(UUID id) {
+    public Optional<ListEntity> findById(UUID id) {
         return listRepository.findById(id);
     }
 
@@ -54,7 +54,7 @@ public class ListService {
      * @param user the user who owns the lists
      * @return a list of lists owned by the user
      */
-    public java.util.List<List> findByUser(User user) {
+    public java.util.List<ListEntity> findByUser(User user) {
         return listRepository.findByUser(user);
     }
 
@@ -64,7 +64,7 @@ public class ListService {
      * @param user the user who has access to the shared lists
      * @return a list of lists shared with the user
      */
-    public java.util.List<List> findSharedWithUser(User user) {
+    public java.util.List<ListEntity> findSharedWithUser(User user) {
         return listShareRepository.findBySharedWithUser(user)
                 .stream()
                 .map(ListShare::getList)
@@ -78,14 +78,14 @@ public class ListService {
      * @param user     the user who owns the list
      * @return the saved list
      */
-    public List save(String listName, User user) {
+    public ListEntity save(String listName, User user) {
         System.out.println("User inside save = " + user);
 
         if (findByUser(user).stream().anyMatch(l -> l.getName().equals(listName))) {
             throw new IllegalArgumentException("List name already exists for user: " + user.getEmail());
         }
 
-        List list = new List();
+        ListEntity list = new ListEntity();
         list.setName(listName);
         list.setUser(user); // 🔥 Obligatoire !
 
@@ -100,4 +100,9 @@ public class ListService {
     public void deleteById(UUID id) {
         listRepository.deleteById(id);
     }
+
+public ListEntity findByIdAndUserId(UUID listId, UUID userId) {
+    return listRepository.findByIdAndUser_Id(listId, userId).orElse(null);
+}
+
 }

--- a/src/main/java/com/easygroup/service/ListShareService.java
+++ b/src/main/java/com/easygroup/service/ListShareService.java
@@ -1,6 +1,6 @@
 package com.easygroup.service;
 
-import com.easygroup.entity.List;
+import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.ListShare;
 import com.easygroup.entity.User;
 import com.easygroup.repository.ListRepository;
@@ -25,7 +25,7 @@ public class ListShareService {
      * @param user the user to share with
      * @return the created ListShare
      */
-    public ListShare shareList(List list, User user) {
+    public ListShare shareList(ListEntity list, User user) {
         list.setIsShared(true);
         listRepository.save(list);
 
@@ -41,7 +41,7 @@ public class ListShareService {
      * @param list the list to unshare
      * @param user the user to unshare with
      */
-    public List unshareList(List list, User user) {
+    public ListEntity unshareList(ListEntity list, User user) {
         listShareRepository.findByListAndSharedWithUser(list, user)
                 .ifPresent(listShareRepository::delete);
 
@@ -61,7 +61,7 @@ public class ListShareService {
      * @param user the user to check
      * @return true if the list is shared with the user
      */
-    public boolean isListSharedWithUser(List list, User user) {
+    public boolean isListSharedWithUser(ListEntity list, User user) {
         return listShareRepository.existsByListAndSharedWithUser(list, user);
     }
 }

--- a/src/main/java/com/easygroup/service/PersonService.java
+++ b/src/main/java/com/easygroup/service/PersonService.java
@@ -5,7 +5,6 @@ import com.easygroup.entity.Person;
 import com.easygroup.repository.ListRepository;
 import com.easygroup.repository.PersonRepository;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +22,6 @@ public class PersonService {
     private final PersonRepository personRepository;
     private final ListRepository listRepository;
 
-    @Autowired
     public PersonService(PersonRepository personRepository, ListRepository listRepository) {
         this.personRepository = personRepository;
         this.listRepository = listRepository;

--- a/src/main/java/com/easygroup/service/UserService.java
+++ b/src/main/java/com/easygroup/service/UserService.java
@@ -2,7 +2,6 @@ package com.easygroup.service;
 
 import com.easygroup.entity.User;
 import com.easygroup.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,7 +19,6 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    @Autowired
     public UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }


### PR DESCRIPTION
## ✅ Fix: Création de personnes

Cette PR corrige un bug bloquant lors de la création de personnes dans une liste utilisateur. Elle inclut :

### ✨ Nouveautés
- Utilisation d’un DTO `PersonRequest` pour sécuriser et valider les données en entrée.
- Utilisation du DTO `PersonResponse` pour structurer proprement les réponses API sans exposer d'entités Hibernate.
- Mise en place d’un mapper `PersonMapper` pour convertir `Person` → `PersonResponse`.
- Refactor du contrôleur `PersonController` :
  - Utilisation du `@Valid @RequestBody PersonRequest` au lieu d’un `Person` brut.
  - Retour propre d’un `PersonResponse` au lieu de l’entité `Person`.

### 🐛 Bugs corrigés
- Erreur `LazyInitializationException` lors de la sérialisation JSON (`HttpMessageNotWritableException`).
- Problème d'accès à des entités en `fetch = LAZY` sans session Hibernate active.

### 🔐 Sécurité & bonnes pratiques
- Isolation des entités JPA du modèle exposé à l’API.
- Meilleure gestion des droits : l'utilisateur doit être propriétaire de la liste pour y ajouter des personnes.

---

🎯 Cette correction améliore la stabilité, la sécurité et la maintenabilité du module de création de personnes.
