### PR TITLE
54 test et debug création tirage draw

### DIFF
--- a/data/easygroup-api.postman_collection.json
+++ b/data/easygroup-api.postman_collection.json
@@ -213,6 +213,20 @@
           }
         },
         {
+          "name": "Get lists by user ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8080/api/lists/user/1",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8080",
+              "path": ["api", "lists", "user", "1"]
+            }
+          }
+        },
+        {
           "name": "Create list",
           "request": {
             "method": "POST",
@@ -389,7 +403,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"ami@example.com\"\n}"
+              "raw": "{\n  \"userId\": \"2\"\n}"
             }
           }
         },

--- a/src/main/java/com/easygroup/controller/ListController.java
+++ b/src/main/java/com/easygroup/controller/ListController.java
@@ -5,18 +5,22 @@ import com.easygroup.dto.ListResponse;
 import com.easygroup.entity.ListEntity;
 import com.easygroup.entity.User;
 import com.easygroup.service.ListService;
+import com.easygroup.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/lists")
 public class ListController {
 
     private final ListService listService;
+    private final UserService userService;
 
-    public ListController(ListService listService){
+    public ListController(ListService listService, UserService userService){
         this.listService = listService;
+        this.userService = userService;
     }
 
     //Create a list for a user
@@ -57,6 +61,25 @@ public class ListController {
         }catch (IllegalArgumentException e){
             return ResponseEntity.notFound().build();
         }
+    }
+
+    //Get all lists of a specific user by ID
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<java.util.List<ListResponse>> getListsByUserId(@PathVariable UUID userId){
+        User foundUser = userService.findById(userId).orElse(null);
+        if(foundUser == null){
+            return ResponseEntity.notFound().build();
+        }
+
+        java.util.List<ListResponse> responseList = listService.findByUser(foundUser).stream()
+                .map(list -> new ListResponse(
+                        list.getId(),
+                        list.getName(),
+                        list.getIsShared()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(responseList);
     }
 
 }

--- a/src/main/java/com/easygroup/controller/ListShareController.java
+++ b/src/main/java/com/easygroup/controller/ListShareController.java
@@ -41,7 +41,13 @@ public class ListShareController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        User userSharedTo = userService.findById(request.userId()).orElse(null);
+        User userSharedTo = null;
+        if (request.userId() != null) {
+            userSharedTo = userService.findById(request.userId()).orElse(null);
+        } else if (request.email() != null) {
+            userSharedTo = userService.findByEmail(request.email()).orElse(null);
+        }
+
         if (userSharedTo == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }

--- a/src/main/java/com/easygroup/dto/ShareListRequest.java
+++ b/src/main/java/com/easygroup/dto/ShareListRequest.java
@@ -2,4 +2,8 @@ package com.easygroup.dto;
 
 import java.util.UUID;
 
-public record ShareListRequest(UUID userId) {}
+/**
+ * Request body for sharing a list with another user.
+ * Allows specifying the target either by user id or by email.
+ */
+public record ShareListRequest(UUID userId, String email) {}

--- a/src/main/java/com/easygroup/repository/ListRepository.java
+++ b/src/main/java/com/easygroup/repository/ListRepository.java
@@ -40,5 +40,13 @@ public interface ListRepository extends JpaRepository<ListEntity, UUID> {
      */
     boolean existsByNameAndUser(String name, User user);
 
+    /**
+     * Find all lists owned by a user using the user id.
+     *
+     * @param userId the id of the owner
+     * @return list of lists belonging to the user
+     */
+    java.util.List<ListEntity> findByUser_Id(UUID userId);
+
 Optional<ListEntity> findByIdAndUser_Id(UUID listId, UUID userId);
 }

--- a/src/main/java/com/easygroup/service/ListService.java
+++ b/src/main/java/com/easygroup/service/ListService.java
@@ -57,6 +57,16 @@ public class ListService {
     }
 
     /**
+     * Find all lists owned by a user using the user id.
+     *
+     * @param userId the id of the user who owns the lists
+     * @return a list of lists owned by the user
+     */
+    public java.util.List<ListEntity> findByUserId(UUID userId) {
+        return listRepository.findByUser_Id(userId);
+    }
+
+    /**
      * Find all lists shared with a user.
      *
      * @param user the user who has access to the shared lists


### PR DESCRIPTION
Added a new endpoint /api/lists/user/{userId} to retrieve lists owned by a particular user

Extended the share list request to accept either a user ID or an email address, preventing errors when the request does not contain an ID

Introduced a repository method to query lists by user ID, enabling the new endpoint functionality

Updated the Postman collection with a “Get lists by user ID” request and corrected the share list request body to use userId